### PR TITLE
Support Node 4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: node_js
 cache: yarn
 
 node_js:
-  - "node"
+  - 4
+  - 6
+  - 8
 
 script: yarn run test
 

--- a/lib/rules/disable-async-await.js
+++ b/lib/rules/disable-async-await.js
@@ -2,7 +2,9 @@
 
 const DEFAULT_ERROR_MESSAGE = 'Using async / await is disabled.';
 
-function handleErrorForContext(context, message = DEFAULT_ERROR_MESSAGE) {
+function handleErrorForContext(context, _message) {
+  const message = _message || DEFAULT_ERROR_MESSAGE;
+
   return function handleErrorForAsyncNode(node) {
     if (node.async) {
       context.report({

--- a/lib/rules/disable-generator-functions.js
+++ b/lib/rules/disable-generator-functions.js
@@ -2,7 +2,9 @@
 
 const DEFAULT_ERROR_MESSAGE = 'Using generator functions are disabled.';
 
-function handleErrorForContext(context, message = DEFAULT_ERROR_MESSAGE) {
+function handleErrorForContext(context, _message) {
+  const message = _message || DEFAULT_ERROR_MESSAGE;
+
   return function handleErrorForGeneratorNode(node) {
     if (node.generator) {
       context.report({

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "standard-version": "^4.2.0"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=4.0.0"
   },
   "license": "MIT",
   "standard-version": {

--- a/tests/lib/rules/disable-async-await.js
+++ b/tests/lib/rules/disable-async-await.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const rule = require('../../../lib/rules/disable-async-await');
-const {
-  RuleTester
-} = require('eslint');
+const RuleTester = require('eslint').RuleTester;
 const DEFAULT_ERROR_MESSAGE = 'Using async / await is disabled.';
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/disable-generator-functions.js
+++ b/tests/lib/rules/disable-generator-functions.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const rule = require('../../../lib/rules/disable-generator-functions');
-const {
-  RuleTester
-} = require('eslint');
+const RuleTester = require('eslint').RuleTester;
 const DEFAULT_ERROR_MESSAGE = 'Using generator functions are disabled.';
 
 const ruleTester = new RuleTester();


### PR DESCRIPTION
The required changes were minimal, and now this plugin can easily be used by other ember-cli addons (which prefer to test against the lowest supported Node version to catch any potential issues).